### PR TITLE
quick SimpleACK fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.home=C:/Program Files/Java/jdk1.6.0_35
+

--- a/src/main/java/com/serotonin/bacnet4j/service/acknowledgement/SimpleAckService.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/acknowledgement/SimpleAckService.java
@@ -1,0 +1,17 @@
+package com.serotonin.bacnet4j.service.acknowledgement;
+
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+/**
+ * Created by Tchuba on 4.4.2016.
+ */
+public class SimpleAckService extends AcknowledgementService {
+    @Override
+    public byte getChoiceId() {
+        return -1;
+    }
+
+    @Override
+    public void write(ByteQueue queue) {
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import com.serotonin.bacnet4j.service.acknowledgement.SimpleAckService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -561,7 +562,7 @@ public class DefaultTransport implements Transport, Runnable {
                 ResponseConsumer consumer = ctx.getConsumer();
 
                 if (ack instanceof SimpleACK)
-                    consumer.success(null);
+                    consumer.success(new SimpleAckService());
                 else if (ack instanceof ComplexACK) {
                     ComplexACK cack = ((ComplexACK) ack);
                     if (cack.isSegmentedMessage()) {


### PR DESCRIPTION
Proposed way to fix the issue with _WriteProperty_ request - timeout exception is thrown in _ServiceFutureImpl_ here:
 ```
 if(ex == null && ack == null && fail == null)
    ex = new BACnetException("Timeout waiting for response.");
```
even though ACK was received. 
_SimpleAckService_ is just a stump and should be expanded if necessary - it's only purpose is for something to be passed instead of null in _DefaultTransport_ to the success method