### PR TITLE
Implement type validation for BTL certification at device write level

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -284,6 +284,7 @@ public class DeviceObject extends BACnetObject {
                 }
             }
         }
+        value.validate();
         return false;
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/logBuffer/LinkedListLogBuffer.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/logBuffer/LinkedListLogBuffer.java
@@ -2,6 +2,8 @@ package com.serotonin.bacnet4j.obj.logBuffer;
 
 import java.util.LinkedList;
 
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
+
 public class LinkedListLogBuffer<T extends ILogRecord> extends LogBuffer<T> {
     private final LinkedList<T> list = new LinkedList<>();
 
@@ -33,5 +35,10 @@ public class LinkedListLogBuffer<T extends ILogRecord> extends LogBuffer<T> {
     @Override
     public String toString() {
         return "LinkedListLogBuffer" + list;
+    }
+
+    @Override
+    public void validate() throws BACnetServiceException {
+        //Unsure of how to validate this
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/logBuffer/LinkedListLogBuffer.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/logBuffer/LinkedListLogBuffer.java
@@ -39,6 +39,6 @@ public class LinkedListLogBuffer<T extends ILogRecord> extends LogBuffer<T> {
 
     @Override
     public void validate() throws BACnetServiceException {
-        //Unsure of how to validate this
+        //Not written, validation not necessary
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/AmbiguousValue.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/AmbiguousValue.java
@@ -31,6 +31,7 @@ package com.serotonin.bacnet4j.type;
 import java.util.Arrays;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Primitive;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
@@ -211,5 +212,10 @@ public class AmbiguousValue extends Encodable {
         } catch (@SuppressWarnings("unused") final BACnetException e) {
             return false;
         }
+    }
+
+    @Override
+    public void validate() throws BACnetServiceException {
+        //No way to validate such a thing
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.exception.ReflectionException;
 import com.serotonin.bacnet4j.obj.ObjectProperties;
 import com.serotonin.bacnet4j.obj.ObjectPropertyTypeDefinition;
@@ -64,6 +65,12 @@ abstract public class Encodable {
 
     abstract public void write(ByteQueue queue, int contextId);
 
+    /**
+     * Optionally validate the value before it is written into our device
+     * @throws BACnetErrorException
+     */
+    abstract public void validate() throws BACnetServiceException;
+    
     @Override
     public String toString() {
         return "Encodable(" + getClass().getName() + ")";
@@ -534,4 +541,5 @@ abstract public class Encodable {
         else
             type.write(queue, contextId);
     }
+
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/EncodedValue.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/EncodedValue.java
@@ -122,6 +122,6 @@ public class EncodedValue extends Encodable {
 
     @Override
     public void validate() throws BACnetServiceException {
-        //Unsure if this is possible
+        //Not necessary
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/EncodedValue.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/EncodedValue.java
@@ -3,6 +3,7 @@ package com.serotonin.bacnet4j.type;
 import java.util.Arrays;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 import com.serotonin.bacnet4j.util.sero.StreamUtils;
@@ -117,5 +118,10 @@ public class EncodedValue extends Encodable {
         if (!Arrays.equals(data, other.data))
             return false;
         return true;
+    }
+
+    @Override
+    public void validate() throws BACnetServiceException {
+        //Unsure if this is possible
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/BaseType.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/BaseType.java
@@ -28,6 +28,7 @@
  */
 package com.serotonin.bacnet4j.type.constructed;
 
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
@@ -44,5 +45,10 @@ abstract public class BaseType extends Encodable {
         write(queue);
         // Write an end tag
         writeContextTag(queue, contextId, false);
+    }
+    
+    @Override
+    public void validate() throws BACnetServiceException {
+        //NO Op
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/DateRange.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/DateRange.java
@@ -43,16 +43,17 @@ public class DateRange extends BaseType implements DateMatchable {
     public DateRange(final Date startDate, final Date endDate) {
         this.startDate = startDate;
         this.endDate = endDate;
-        validate();
+        validateInput();
     }
 
     public DateRange(final ByteQueue queue) throws BACnetException {
         startDate = read(queue, Date.class);
         endDate = read(queue, Date.class);
-        validate();
+        validateInput();
     }
 
-    private void validate() {
+    
+    private void validateInput() {
         if (startDate.getYear() != Date.UNSPECIFIED_YEAR && endDate.getYear() == Date.UNSPECIFIED_YEAR
                 || startDate.getYear() == Date.UNSPECIFIED_YEAR && endDate.getYear() != Date.UNSPECIFIED_YEAR)
             throw new BACnetRuntimeException("start and end years must both be specific or unspecific");

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/PropertyValue.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/PropertyValue.java
@@ -29,6 +29,7 @@
 package com.serotonin.bacnet4j.type.constructed;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.ThreadLocalObjectTypeStack;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
@@ -65,6 +66,11 @@ public class PropertyValue extends BaseType {
         return propertyIdentifier;
     }
 
+    @Override
+    public void validate() throws BACnetServiceException {
+        this.value.validate();
+    }
+    
     @SuppressWarnings("unchecked")
     public <T extends Encodable> T getValue() {
         return (T) value;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/Primitive.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/Primitive.java
@@ -29,6 +29,7 @@
 package com.serotonin.bacnet4j.type.primitive;
 
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
@@ -175,18 +176,15 @@ abstract public class Primitive extends Encodable {
 
     protected long readTag(final ByteQueue queue, byte type_Id) throws BACnetErrorException {
         final byte b = queue.pop();
-        int tagNumber = (b & 0xff) >> 4;
-        boolean contextSpecific = (b & 8) != 0;
+        typeId = type_Id;
+        tagNumber = (b & 0xff) >> 4;
+        contextSpecific = (b & 8) != 0;
         long length = b & 7;
 
         if (tagNumber == 0xf)
             // Extended tag.
             tagNumber = queue.popU1B();
-
-         //if the tagNumber its not contextSpecific, validate the type
-        if (!contextSpecific && tagNumber != type_Id){
-            throw new BACnetErrorException(ErrorClass.property, ErrorCode.invalidDataType);           
-        }       
+      
         
         if (length == 5) {
             length = queue.popU1B();
@@ -197,5 +195,16 @@ abstract public class Primitive extends Encodable {
         }
 
         return length;
+    }
+    private int tagNumber;
+    private int typeId;
+    private boolean contextSpecific;
+    
+    @Override
+    public void validate() throws BACnetServiceException {
+        //if the tagNumber its not contextSpecific, validate the type
+       if (!contextSpecific && tagNumber != typeId){
+           throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);           
+       } 
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned16.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned16.java
@@ -28,11 +28,13 @@
  */
 package com.serotonin.bacnet4j.type.primitive;
 
+import java.math.BigInteger;
+
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
-import java.math.BigInteger;
 
 public class Unsigned16 extends UnsignedInteger {
     private static final int MAX = 0xffff;
@@ -46,14 +48,19 @@ public class Unsigned16 extends UnsignedInteger {
 
     public Unsigned16(final ByteQueue queue) throws BACnetErrorException {
         super(queue);
+    }
+    
+    @Override
+    public void validate() throws BACnetServiceException {
+        super.validate();
         if (super.isSmallValue()) {
             if (super.intValue() > MAX) {
-                throw new BACnetErrorException(ErrorClass.property, ErrorCode.valueOutOfRange);
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
             }
         } else {
             if (super.bigIntegerValue().compareTo(BIGMAX) > 0) {
-                throw new BACnetErrorException(ErrorClass.property, ErrorCode.valueOutOfRange);
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
             }
-        }
+        }        
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned32.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned32.java
@@ -28,11 +28,12 @@
  */
 package com.serotonin.bacnet4j.type.primitive;
 
-import com.serotonin.bacnet4j.exception.BACnetErrorException;
-import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
-import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import java.math.BigInteger;
 
+import com.serotonin.bacnet4j.exception.BACnetErrorException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class Unsigned32 extends UnsignedInteger {
@@ -51,13 +52,18 @@ public class Unsigned32 extends UnsignedInteger {
 
     public Unsigned32(final ByteQueue queue) throws BACnetErrorException {
         super(queue);
+    }
+    
+    @Override
+    public void validate() throws BACnetServiceException {
+        super.validate();
         if (super.isSmallValue()) {
             if (super.intValue() > MAX) {
-                throw new BACnetErrorException(ErrorClass.property, ErrorCode.valueOutOfRange);
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
             }
         } else {
             if (super.bigIntegerValue().compareTo(BIGMAX) > 0) {
-                throw new BACnetErrorException(ErrorClass.property, ErrorCode.valueOutOfRange);
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
             }
         }
     }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned8.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned8.java
@@ -28,11 +28,13 @@
  */
 package com.serotonin.bacnet4j.type.primitive;
 
+import java.math.BigInteger;
+
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
-import java.math.BigInteger;
 
 public class Unsigned8 extends UnsignedInteger {
     private static final int MAX = 0xff;
@@ -47,13 +49,18 @@ public class Unsigned8 extends UnsignedInteger {
 
     public Unsigned8(final ByteQueue queue) throws BACnetErrorException {
         super(queue);
+    }
+    
+    @Override
+    public void validate() throws BACnetServiceException {
+        super.validate();
         if (super.isSmallValue()) {
             if (super.intValue() > MAX) {
-                throw new BACnetErrorException(ErrorClass.property, ErrorCode.valueOutOfRange);
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
             }
         } else {
             if (super.bigIntegerValue().compareTo(BIGMAX) > 0) {
-                throw new BACnetErrorException(ErrorClass.property, ErrorCode.valueOutOfRange);
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
             }
         }
     }

--- a/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
@@ -1,5 +1,9 @@
 package com.serotonin.bacnet4j.obj;
 
+import static org.junit.Assert.fail;
+
+import java.math.BigInteger;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -8,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.serotonin.bacnet4j.AbstractTest;
 import com.serotonin.bacnet4j.TestUtils;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.BACnetArray;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
 import com.serotonin.bacnet4j.type.constructed.NameValue;
@@ -27,7 +32,7 @@ import com.serotonin.bacnet4j.type.primitive.SignedInteger;
 import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.RequestUtils;
-import java.math.BigInteger;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class BACnetObjectTest extends AbstractTest {
     static final Logger LOG = LoggerFactory.getLogger(BACnetObjectTest.class);
@@ -41,6 +46,7 @@ public class BACnetObjectTest extends AbstractTest {
                         new NameValue("tag2", Null.instance)));
         d2.writePropertyInternal(PropertyIdentifier.forId(6789),
                 new BACnetArray<>(new Real(0), new Real(1), new Real(2)));
+        d2.writePropertyInternal(PropertyIdentifier.protocolVersion, new CharacterString(CharacterString.Encodings.ANSI_X3_4, "hxzy-1.01"));
     }
 
     @Test
@@ -196,6 +202,19 @@ public class BACnetObjectTest extends AbstractTest {
         }, ErrorClass.property, ErrorCode.invalidDataType);
     }
 
+    @Test
+    public void primitiveReadIncorrectType() {
+        //Standard test 135.1-2013, 9.22.2.3 only applies to writes
+        
+        try{
+            //Internally this gets converted to an UnsignedInteger on receipt of the response so I'm not sure how to assert the
+            //  response is correct
+            RequestUtils.readProperty(d1, rd2, d2.getId(), PropertyIdentifier.protocolVersion, null);
+        }catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+    
     @Test
     public void writeOutOfRange() {
         //Standard test 135.1-2013, 9.22.2.4 - write a Unsigned16 with a value out of range.

--- a/src/test/java/com/serotonin/bacnet4j/service/acknowledgement/InvalidPropertyValueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/acknowledgement/InvalidPropertyValueTest.java
@@ -35,7 +35,7 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
  */
 public class InvalidPropertyValueTest {
 
-    //Uncomment to run test @Test
+    @Test
     public void testParse() {
         
         List<Result> deviceResultList = new ArrayList<>();
@@ -59,9 +59,8 @@ public class InvalidPropertyValueTest {
         mockAck.write(queue);
         
         try {
-            ReadPropertyMultipleAck ack = new ReadPropertyMultipleAck(queue);
+            new ReadPropertyMultipleAck(queue);
         } catch (BACnetException e) {
-            e.printStackTrace();
             fail(e.getMessage());
         }
         

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequestTest.java
@@ -1,5 +1,7 @@
 package com.serotonin.bacnet4j.service.confirmed;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,7 +12,6 @@ import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.test.TestNetwork;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkUtils;
-import com.serotonin.bacnet4j.service.acknowledgement.AcknowledgementService;
 import com.serotonin.bacnet4j.service.acknowledgement.ReadPropertyAck;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.type.constructed.Address;
@@ -20,8 +21,6 @@ import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
-import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
 
 public class ReadPropertyRequestTest {
     private final TestNetworkMap map = new TestNetworkMap();

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
@@ -14,6 +14,7 @@ import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.TestUtils;
 import com.serotonin.bacnet4j.enums.Month;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.npdu.test.TestNetwork;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
 import com.serotonin.bacnet4j.obj.AnalogInputObject;
@@ -460,6 +461,11 @@ public class ReadRangeRequestTest {
         @Override
         public void write(final ByteQueue queue, final int contextId) {
             throw new RuntimeException("not implemented");
+        }
+
+        @Override
+        public void validate() throws BACnetServiceException {
+            //Not necessary
         }
     }
 


### PR DESCRIPTION
This is one possible solution that uses validation just prior to writing the value to the DeviceObject to fix #43 