### PR TITLE
Fix dependencies errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,12 @@ group = 'com.infiniteautomation'
 version = '6.0.0-SNAPSHOT'
 
 repositories {
-    jcenter()
+    jcenter() {
+        metadataSources {
+            mavenPom()
+            artifact()
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.scream3r:jssc:2.8.0'
-    compile 'org.slf4j:slf4j-api:1.8'
+    compile 'org.slf4j:slf4j-api:1.8.0-beta2'
     compile 'ai.serotonin.oss:sero-scheduler:1.1.0'
     compile 'ai.serotonin.oss:sero-warp:1.0.0'
     

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.8</version>
+			<version>1.8.0-beta2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
I got some dependencies errors when I'm build using Gradle or Maven.

One commit change slf4j-api:1.8 (doesn't exist) for slf4j-api:1.8.0-beta2 
I matched the version with slf4j-simple.

The other commit fix jcenter repository declaration, so it looks for artifact when no metadata are found. Otherwise, sero-warp:1.0.0 just fail when using gradle.

Maven output:
`Could not find artifact org.slf4j:slf4j-api:pom:1.8 in jcenter (https://jcenter.bintray.com)`

Gradle output:
`Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find org.slf4j:slf4j-api:1.8.
     Searched in the following locations:
       - https://jcenter.bintray.com/org/slf4j/slf4j-api/1.8/slf4j-api-1.8.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project :
   > Could not find ai.serotonin.oss:sero-warp:1.0.0.
     Searched in the following locations:
       - https://jcenter.bintray.com/ai/serotonin/oss/sero-warp/1.0.0/sero-warp-1.0.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project :

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
`